### PR TITLE
Fix missing wandb import

### DIFF
--- a/src/fruit_project/utils/early_stop.py
+++ b/src/fruit_project/utils/early_stop.py
@@ -3,6 +3,7 @@ import pathlib
 from tqdm import tqdm
 from omegaconf import DictConfig
 from wandb.sdk.wandb_run import Run
+import wandb
 import torch.nn as nn
 from typing import List, Optional, Tuple
 from pathlib import Path


### PR DESCRIPTION
## Summary
- import wandb in `EarlyStopping`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686081cc7c64832fa13ed97cd9b34bda